### PR TITLE
Add eMMC to allowable disk types

### DIFF
--- a/Proxmox/Sys/Block.pm
+++ b/Proxmox/Sys/Block.pm
@@ -171,6 +171,8 @@ sub get_partition_dev {
 	return "${dev}$partnum";
     } elsif ($dev =~ m|^/dev/nvme\d+n\d+$|) {
 	return "${dev}p$partnum";
+    } elsif ($dev =~ m|^/dev/mmcblk\d+$|) {
+	return "${dev}p$partnum";
     } else {
 	die "unable to get device for partition $partnum on device $dev\n";
     }


### PR DESCRIPTION
This fixes the bug that does not show mmc devices.  

Here is the long standing forum post of it very well proven to work: https://forum.proxmox.com/threads/unable-to-get-device-for-partition-1-on-device-dev-mmcblk0.42348/

And the user that found and blogged the fix: https://ibug.io/blog/2022/03/install-proxmox-ve-emmc/

**The reasoning of Proxmox not supporting eMMC has been debunked (read to the very end):** https://ibug.io/blog/2023/07/prolonging-emmc-life-span-with-proxmox-ve/